### PR TITLE
Switch to model_config for Pydantic v2

### DIFF
--- a/ash/models.py
+++ b/ash/models.py
@@ -1,10 +1,9 @@
 __all__ = ["OPModel", "Field"]
 
-import json
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 def camelize(src: str) -> str:
@@ -16,14 +15,11 @@ def camelize(src: str) -> str:
 class OPModel(BaseModel):
     """Base API model."""
 
-    class Config:
-        """API model config."""
-
-        orm_mode = True
-        allow_population_by_field_name = True
-        alias_generator = camelize
-        json_loads = json.loads
-        json_dumps = json.dumps
+    model_config = ConfigDict(
+        from_attributes=True,
+        populate_by_name=True,
+        alias_generator=camelize,
+    )
 
 
 class ServiceConfigModel(OPModel):


### PR DESCRIPTION
## Summary
- modernize Pydantic setup by replacing the inner `Config` class with `model_config`

## Testing
- `ruff check`
- `mypy ash/models.py`

------
https://chatgpt.com/codex/tasks/task_e_68556a6fd608832dbf63772dc0393fd2