### PR TITLE
Fix hyphenated k8s hostnames

### DIFF
--- a/ash/services.py
+++ b/ash/services.py
@@ -292,7 +292,7 @@ class Services:
             logger.info(f"Starting {service_name} {addon_string} (image: {image})")
 
             kwargs = service_config.model_dump()
-            hostname = slugify(f"aysvc_{service_name}", separator="_")
+            hostname = slugify(f"aysvc-{service_name}")
 
             environment = {
                 "AYON_SERVER_URL": config.server_url,


### PR DESCRIPTION
## Summary
- ensure Kubernetes hostnames use hyphens by default

## Testing
- `python -m pre_commit run --files ash/services.py` *(fails: types-kubernetes package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858efd6ad20832db797628888b73671